### PR TITLE
Add to DatabaseServiceRegistration sqlServer register.

### DIFF
--- a/BlazorSpark.Library/BlazorSpark.Library.csproj
+++ b/BlazorSpark.Library/BlazorSpark.Library.csproj
@@ -29,6 +29,7 @@
     <PackageReference Include="MailKit" Version="4.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="7.0.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.5" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="7.0.3" />
     <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="7.0.0" />

--- a/BlazorSpark.Library/Database/DatabaseServiceRegistration.cs
+++ b/BlazorSpark.Library/Database/DatabaseServiceRegistration.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.EntityFrameworkCore;
+﻿using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using System;
@@ -47,6 +48,35 @@ namespace BlazorSpark.Library.Database
                 services.AddDbContextFactory<T>(options =>
                 {
                     options.UseNpgsql(
+                        connectionString
+                    ).UseSnakeCaseNamingConvention();
+                });
+            }
+            else if (dbType == DatabaseTypes.sqlserver)
+            {
+                var dbTrustCertificate = config.GetValue<bool>("DB_TRUST_CERTIFICATE");
+                var dbIntegratedSecurity = config.GetValue<bool>("DB_INTEGRATED_SECURITY");
+                string connectionString = string.Empty;
+
+                if (dbIntegratedSecurity)
+                {
+                    connectionString = $"Server={dbHost};Database={dbName};Integrated Security={dbIntegratedSecurity}";
+
+                    if (dbTrustCertificate)                    
+                        connectionString = $"Server={dbHost};Database={dbName};Integrated Security={dbIntegratedSecurity};TrustServerCertificate={dbTrustCertificate}";                    
+                }
+                else if (dbTrustCertificate)
+                {
+                    connectionString = $"Server={dbHost};Database={dbName};User Id={dbUser};Password={dbPassword};TrustServerCertificate={dbTrustCertificate}";
+                }
+                else 
+                {
+                    connectionString = $"Server={dbHost};Database={dbName};User Id={dbUser};Password={dbPassword};";
+                }
+
+                services.AddDbContextFactory<T>(options =>
+                {
+                    options.UseSqlServer(
                         connectionString
                     ).UseSnakeCaseNamingConvention();
                 });

--- a/BlazorSpark.Library/Database/DatabaseTypes.cs
+++ b/BlazorSpark.Library/Database/DatabaseTypes.cs
@@ -11,5 +11,6 @@ namespace BlazorSpark.Library.Database
 		public const string mysql = nameof(mysql);
 		public const string postgres = nameof(postgres);
 		public const string sqlite = nameof(sqlite);
+		public const string sqlserver = nameof(sqlserver);
 	}
 }


### PR DESCRIPTION
This PR register method permit to persist the database in SQLServer database. 

- Add sqlserver to DatabaseTypes.
- Add Microsoft.EntityFrameworkCore.SqlServer ver="7.0.5" package to BlazorSpark.Library.
- Register SqlServer to ContextFactory.
- Add two extra .env values to handle the posible sqlserver connection strings. 
- DB_TRUST_CERTIFICATE=true
- DB_INTEGRATED_SECURITY=true

This is my first contribution to the project let me know your suggestions Thanks. 

