### PR TITLE
Update appsettings.json to fix misnamed password entries

### DIFF
--- a/BlazorSpark.Templates/working/templates/BlazorSpark/appsettings.json
+++ b/BlazorSpark.Templates/working/templates/BlazorSpark/appsettings.json
@@ -26,21 +26,21 @@
                     "Host": "ENV_DB_HOST",
                     "Port": "ENV_DB_PORT",
                     "Username": "ENV_DB_USERNAME",
-                    "Pasword": "ENV_DB_PASSWORD"
+                    "Password": "ENV_DB_PASSWORD"
                 },
                 "Postgres": {
                     "Database": "ENV_DB_DATABASE",
                     "Host": "ENV_DB_HOST",
                     "Port": "ENV_DB_PORT",
                     "Username": "ENV_DB_USERNAME",
-                    "Pasword": "ENV_DB_PASSWORD"
+                    "Password": "ENV_DB_PASSWORD"
                 },
                 "Sqlserver": {
                     "Database": "ENV_DB_DATABASE",
                     "Host": "ENV_DB_HOST",
                     "Port": "ENV_DB_PORT",
                     "Username": "ENV_DB_USERNAME",
-                    "Pasword": "ENV_DB_PASSWORD",
+                    "Password": "ENV_DB_PASSWORD",
                     "DbTrustCertificate": false,
                     "DbIntegratedSecurity": false
                 }


### PR DESCRIPTION
Hi, just started exploring Blazor Spark for the first time (for a project I'm about to start work on) and ran into an issue attempting to use Postgres.

Tracked it down to a typo in appsettings.json.

This PR is to fix the typo (for all DB providers).

I haven't included it in this PR, as I haven't had chance to see if it would break anything, but it looks like Smpt is a mis-spelling of Smtp also?

![image](https://github.com/blazor-spark/blazor-spark/assets/102787/8e35c75b-c417-4c8c-84d7-4aed8b309f21)

Thanks!