### PR TITLE
Use Path.DirectorySeparatorChar in spark open

### DIFF
--- a/BlazorSpark.Console/Commands/Project/OpenSolutionCommand.cs
+++ b/BlazorSpark.Console/Commands/Project/OpenSolutionCommand.cs
@@ -14,7 +14,8 @@ namespace BlazorSpark.Console.Commands.Project
         public void Execute()
         {
             string appName = UserApp.GetAppName();
-            Process.Start(new ProcessStartInfo($@"{Directory.GetCurrentDirectory()}\{appName}.sln") { UseShellExecute = true });
+            char dirSep = Path.DirectorySeparatorChar;
+            Process.Start(new ProcessStartInfo($@"{Directory.GetCurrentDirectory()}{dirSep}{appName}.sln") { UseShellExecute = true });
         }
     }
 }


### PR DESCRIPTION
The 'spark open' command crashes in Linux because of the backslash character. Whilst this will still not be doing anything useful, it at least stops it from crashing.