### PR TITLE
Fix register message in Login.cshtml

### DIFF
--- a/BlazorSpark.Templates/working/templates/BlazorSpark/Pages/Auth/Login.cshtml
+++ b/BlazorSpark.Templates/working/templates/BlazorSpark/Pages/Auth/Login.cshtml
@@ -129,7 +129,7 @@
 		</form>
 		<div class="mt-5">
 			<a href="/register" class="text-secondary">
-				Already registered? Sign in
+				Don't have an account? Sign up
 			</a>
 		</div>
 	</article>


### PR DESCRIPTION
The message for the link to the register page seemed to have been copied from the register page, and didn't make sense in the context.
Changed it to be same as the wording in the Example login page.